### PR TITLE
Fix positioning of the printer ON/OFF button (with title)

### DIFF
--- a/files/homeassistant/hacs_version/individual_control.yaml
+++ b/files/homeassistant/hacs_version/individual_control.yaml
@@ -8,7 +8,11 @@ cards:
     show_state: false
     layout: icon_name
     tap_action:
-      action: toggle
+      action: |
+        [[[
+          if (entity) return 'toggle';
+          else return 'none';
+        ]]]
     confirmation:
       text: Toggle Printer Power?
     state:
@@ -22,8 +26,14 @@ cards:
       grid:
         - grid-template-columns: |
             [[[
-              if (entity) return '40% 1fr';
-              else return '0% 1fr';
+              if (entity) return '20% 1fr 20%';
+              else return '20% 1fr 20%';
+            ]]]
+      icon:
+        - width: |
+            [[[
+              if (entity) return '50px';
+              else return '0px';
             ]]]
       name:
         - text-wrap: balance

--- a/files/homeassistant/hacs_version/individual_control.yaml
+++ b/files/homeassistant/hacs_version/individual_control.yaml
@@ -32,12 +32,13 @@ cards:
       icon:
         - width: |
             [[[
-              if (entity) return '50px';
+              if (entity) return '65px';
               else return '0px';
             ]]]
+        - padding-left: 20px
       name:
         - text-wrap: balance
-        - font-weight: bold
+        - font-size: 1.4em
     card_mod:
       style: |
         ha-card {

--- a/files/homeassistant/hacs_version/individual_control.yaml
+++ b/files/homeassistant/hacs_version/individual_control.yaml
@@ -1,48 +1,40 @@
 type: vertical-stack
 cards:
-  - type: horizontal-stack
-    cards:
-      - type: conditional
-        conditions:
-          - condition: state
-            entity: switch.{HA_PRINTER_SMARTPLUG_NAME}
-            state: unavailable
-        card:
-          type: custom:gap-card
-      - type: conditional
-        conditions:
-          - condition: state
-            entity: switch.{HA_PRINTER_SMARTPLUG_NAME}
-            state_not: unavailable
-        card:
-          type: custom:button-card
-          show_name: false
-          show_icon: true
-          tap_action:
-            action: toggle
-          entity: switch.{HA_PRINTER_SMARTPLUG_NAME}
-          icon: mdi:printer-3d
-          confirmation:
-            text: Toggle Printer Power?
-          state:
-            - value: 'on'
-              icon: mdi:power
-              color: green
-            - value: 'off'
-              icon: mdi:power
-              color: grey
-          aspect_ratio: 2
-          card_mod:
-            style: |
-              ha-card {
-                background: rgba(0,0,0,0);
-                border: none;
-                box-shadow: none !important;
-              }
-      - type: custom:mushroom-title-card
-        title: {PRINTER_TITLE}
-        alignment: center
-      - type: custom:gap-card
+  - type: custom:button-card
+    entity: switch.{HA_PRINTER_SMARTPLUG_NAME}
+    name: {PRINTER_TITLE}
+    icon: mdi:printer-3d
+    show_icon: true
+    show_state: false
+    layout: icon_name
+    tap_action:
+      action: toggle
+    confirmation:
+      text: Toggle Printer Power?
+    state:
+      - value: 'on'
+        icon: mdi:power
+        color: green
+      - value: 'off'
+        icon: mdi:power
+        color: grey
+    styles:
+      grid:
+        - grid-template-columns: |
+            [[[
+              if (entity) return '40% 1fr';
+              else return '0% 1fr';
+            ]]]
+      name:
+        - text-wrap: balance
+        - font-weight: bold
+    card_mod:
+      style: |
+        ha-card {
+          background: rgba(0,0,0,0);
+          border: none;
+          box-shadow: none !important;
+        }
   - type: custom:gap-card
     height: 5
   - type: custom:hui-element


### PR DESCRIPTION
I was (finally) able to fix the smart switch button positioning (yeah, it was really hurting my brain 😄 )
I also simplified the whole card using just a `custom:button-card` without `custom:mushroom-title-card` nor `custom:gap-card`
Here some examples:

**Switch non-existing (switch.deleteme) and short description**
![image](https://github.com/WolfwithSword/Bambu-HomeAssistant-Flows/assets/38808827/eb11e61a-43ac-4dea-88e0-e7d3ee8b689a)

**Switch non-existing (switch.deleteme) and (very) long description**
![image](https://github.com/WolfwithSword/Bambu-HomeAssistant-Flows/assets/38808827/1a10a82c-2087-4815-ba1b-7ffb0104fec9)

**Switch existing and short description**
![image](https://github.com/WolfwithSword/Bambu-HomeAssistant-Flows/assets/38808827/6d602340-6a3a-4c75-bf68-63ab8970a37c)

**Switch existing and (very) long description**
![image](https://github.com/WolfwithSword/Bambu-HomeAssistant-Flows/assets/38808827/4e562817-687d-4ecf-83d9-750335598c0e)
